### PR TITLE
Remove version number based file API check

### DIFF
--- a/bin/mdwatch.js
+++ b/bin/mdwatch.js
@@ -1,13 +1,7 @@
 #!/usr/bin/env node
 
 var mdwatch = require('../');
-
-var existsSync;
-if (process.version.indexOf('v0.8') === 0) {
-  existsSync = require('fs').existsSync;
-} else {
-  existsSync = require('path').existsSync;
-}
+var existsSync = require('fs').existsSync || require('path').existsSync;
 
 function usage(mes) {
   if (mes) {


### PR DESCRIPTION
This PR removes the fixed Node.js version number based check for `fileExists`. I left the `path` version there in place even though I really doubt if anyone still really uses 0.7... :)